### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: [ "3.10" ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/test_update_leaderboard.yml
+++ b/.github/workflows/test_update_leaderboard.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
         with:
           python-version: '3.10'
           cache: "pip"

--- a/.github/workflows/update_pypi.yml
+++ b/.github/workflows/update_pypi.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
         - name: Checkout code
-          uses: actions/checkout@v3
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
         - name: Set up Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
           with:
             python-version: '3.10'
             cache: "pip"
@@ -50,7 +50,7 @@ jobs:
             git push origin v${{ github.event.inputs.version }}
 
         - name: Create Release
-          uses: softprops/action-gh-release@v1
+          uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v1
           with:
             name: Release v${{ github.event.inputs.version }}
             tag_name: v${{ github.event.inputs.version }}


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `test_update_leaderboard.yml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500…` |
| `test_update_leaderboard.yml` | `actions/setup-python` | `v4` | `v4` | `7f4fc3e22c37…` |
| `integration_tests.yml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500…` |
| `integration_tests.yml` | `actions/setup-python` | `v4` | `v4` | `7f4fc3e22c37…` |
| `update_pypi.yml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500…` |
| `update_pypi.yml` | `actions/setup-python` | `v4` | `v4` | `7f4fc3e22c37…` |
| `update_pypi.yml` | `softprops/action-gh-release` | `v1` | `v1` | `de2c0eb89ae2…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#65